### PR TITLE
Remove HUD timer when ECM Jammer is deactivated

### DIFF
--- a/lua/hud/HudAssaultCorner.lua
+++ b/lua/hud/HudAssaultCorner.lua
@@ -1678,6 +1678,8 @@ if VoidUI.options.enable_assault then
 			set_active(self, active)
 			if active then
 				managers.hud:add_ecm_timer(self._unit)
+			else
+				managers.hud:remove_ecm_timer(self._unit)
 			end
 		end
 	end

--- a/lua/managers/HudManager.lua
+++ b/lua/managers/HudManager.lua
@@ -622,13 +622,41 @@ elseif RequiredScript == "lib/managers/hudmanagerpd2" then
 				self._hud_assault_corner:set_assault_phase()
 			end
 		end
-		
+
 		HUDManager.add_ecm_timer = HUDManager.add_ecm_timer or function(self, unit)
 			if unit and unit:base():battery_life() then
+				-- index -> unit
 				self._jammers = self._jammers or {}
-				table.insert(self._jammers, unit)
+				-- unit -> index
+				self._jammer_indices = self._jammer_indices or {}
+
+				-- insert into _jammers; same functionality as table.insert, except we know the index
+				local index = #self._jammers + 1
+				self._jammers[index] = unit
+				-- store index
+				self._jammer_indices[unit] = index
+
 				self:start_ecm_timer()
 			end
+		end
+
+		HUDManager.remove_ecm_timer = HUDManager.remove_ecm_timer or function(self, unit)
+			if not self._jammers then
+				return
+			end
+
+			-- get the index of unit in _jammers
+			local pos = self._jammer_indices[unit]
+			if not pos then
+				-- this shouldn't happen, but don't remove a timer if we don't have it.
+				return
+			end
+
+			-- remove from tables
+			table.remove(self._jammers, pos)
+			self._jammer_indices[unit] = nil
+			-- stop the timer
+			self._hud_assault_corner:stop_ecm()
 		end
 		
 		HUDManager.start_ecm_timer = HUDManager.start_ecm_timer or function(self)		

--- a/lua/managers/HudManager.lua
+++ b/lua/managers/HudManager.lua
@@ -625,17 +625,8 @@ elseif RequiredScript == "lib/managers/hudmanagerpd2" then
 
 		HUDManager.add_ecm_timer = HUDManager.add_ecm_timer or function(self, unit)
 			if unit and unit:base():battery_life() then
-				-- index -> unit
 				self._jammers = self._jammers or {}
-				-- unit -> index
-				self._jammer_indices = self._jammer_indices or {}
-
-				-- insert into _jammers; same functionality as table.insert, except we know the index
-				local index = #self._jammers + 1
-				self._jammers[index] = unit
-				-- store index
-				self._jammer_indices[unit] = index
-
+				table.insert(self._jammers, unit)
 				self:start_ecm_timer()
 			end
 		end
@@ -645,18 +636,15 @@ elseif RequiredScript == "lib/managers/hudmanagerpd2" then
 				return
 			end
 
-			-- get the index of unit in _jammers
-			local pos = self._jammer_indices[unit]
-			if not pos then
-				-- this shouldn't happen, but don't remove a timer if we don't have it.
-				return
+			table.remove(self._jammers, table.index_of(self._jammers, unit))
+			if #self._jammers > 0 then
+				-- If there's other ECM's active, switch to them
+				self.start_ecm_timer()
+			else
+				-- No ECM's active, switch back to the Pagers panel
+				self._hud_assault_corner:stop_ecm()
+				self._hud_assault_corner:ecm_timer(0)
 			end
-
-			-- remove from tables
-			table.remove(self._jammers, pos)
-			self._jammer_indices[unit] = nil
-			-- stop the timer
-			self._hud_assault_corner:stop_ecm()
 		end
 		
 		HUDManager.start_ecm_timer = HUDManager.start_ecm_timer or function(self)		


### PR DESCRIPTION
**Problem**
When placing an ECM Jammer on a destroyable surface (for example, the glass window on the van, or the paper files that can be destroyed) and destroying the surface before the ECM Jammer timer runs out, all clients (and host) using VoidUI will crash. This only occurs if _at least_ one other ECM Jammer has been placed for the entire heist, even if the previously placed ECM Jammer runs out before the new one is placed.

When the client crashes, the crash log only shows a generic access violation with no useful stack trace. This was only tested with one crash so perhaps there's a different case where a stack trace is produced.

**Technical Details**
VoidUI overrides the `set_active` function in `ECMJammerBase`. When an ECM Jammer is activated, `add_ecm_timer` is called. However, nothing is done when `active` is `false`, causing the timer to still run on the HUD even when the ECM Jammer is destroyed. I assume that this eventually leads to something becoming `nil`, resulting in the crash since a `nil` value is being referenced and results in an unrecoverable error.

**Fix**
The proposed fix adds a new function `remove_ecm_timer` (alternative of `add_ecm_timer`), which removes a timer when `active` is `false` in the `set_active` function.