### PR TITLE
Assault Panel Improvements

### DIFF
--- a/lua/hud/HudAssaultCorner.lua
+++ b/lua/hud/HudAssaultCorner.lua
@@ -387,7 +387,7 @@ if VoidUI.options.enable_assault then
 				font = "fonts/font_medium_noshadow_mf",
 				font_size = panel_h / 2
 			})
-			local is_level_ghostable = managers.job:is_level_ghostable(managers.job:current_level_id()) and managers.groupai and managers.groupai:state():whisper_mode()
+			local is_level_ghostable = managers.groupai and managers.groupai:state():whisper_mode()
 			local cuffed_panel = icons_panel:panel({
 				name = "cuffed_panel",
 				w = panel_w,
@@ -1462,7 +1462,7 @@ if VoidUI.options.enable_assault then
 			local icon_noreturnbox = point_of_no_return_panel:child("icon_noreturnbox")
 			local point_of_no_return_timer = point_of_no_return_panel:child("point_of_no_return_timer")
 			wait(delay_time)
-			self:_set_hostage_offseted(true, true)
+			self:_hide_hostages()
 			
 			background:set_x(noreturnbox_panel:w())
 			border:set_x(background:x() - 1 * self._scale)

--- a/lua/hud/HudAssaultCorner.lua
+++ b/lua/hud/HudAssaultCorner.lua
@@ -1462,7 +1462,7 @@ if VoidUI.options.enable_assault then
 			local icon_noreturnbox = point_of_no_return_panel:child("icon_noreturnbox")
 			local point_of_no_return_timer = point_of_no_return_panel:child("point_of_no_return_timer")
 			wait(delay_time)
-			self:_hide_hostages()
+			self:_set_hostage_offseted(true, true)
 			
 			background:set_x(noreturnbox_panel:w())
 			border:set_x(background:x() - 1 * self._scale)


### PR DESCRIPTION
This will fix the overlapping between the point of no return timer and the hostage counters.

I also removed the check for if the heist is stealthable to fix the problem with the ecm timer and pager counter not being visible on heists such as Big Oil day 2 that can be half stealthed. 