### PR TITLE
Allow Extensions to use VoidUI Menu much easier

### DIFF
--- a/Main.lua
+++ b/Main.lua
@@ -271,12 +271,6 @@ Hooks:Add("MenuManagerBuildCustomMenus", "MenuManagerBuildCustomMenus_VoidUI", f
 	end
 end)
 
-Hooks:PostHook(MenuManager, "update", "update_menu", function(self, t, dt)
-	if VoidUI.Menu and VoidUI.Menu.update and VoidUI.Menu._enabled then
-		VoidUI.Menu:update(t, dt)
-	end
-end)
-
 if RequiredScript then
 	local requiredScript = RequiredScript:lower()
 		if VoidUI.hook_files[requiredScript] then


### PR DESCRIPTION
With these changes it's much easier to make an instance of VoidUI Menu that saves options to a different file.

This will be used by Infobox and HotlineMiamiVibe (recolor) extensions made by me. With these changes I basically don't need to override any functions beside Close() function.